### PR TITLE
Make [SlackLogger] singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 0.0.1
+## 1.0.0
 
-* Initial Release
+- Made [SlackLogger] singleton.
 
 ## 0.0.2
 
-* Example Added
+- Example Added
+
+## 0.0.1
+
+- Initial Release

--- a/README.md
+++ b/README.md
@@ -7,29 +7,49 @@
 A simple dart package to send message to slack channel via slack webhook
 
 ## Usage
+
 To use this plugin, add `slack_logger` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/platform-integration/platform-channels).
 
 ### Steps before using this package
 
-* Add Apps to https://api.slack.com/apps/.
+- Add Apps to https://api.slack.com/apps/.
 
-* Go to Incoming Webhook Link and Enable it.
+- Go to Incoming Webhook Link and Enable it.
 
-* Create your slack channel.
+- Create your slack channel.
 
-* Create new webhook and link slack channel.
-
+- Create new webhook and link slack channel.
 
 ### You are good to go now 👍
 
-#### Send:
-
+### Initialize [SlackLogger]
 
 ```dart
-SlackLogger.send(
-    "[url from web hook]",
-    "This is a error log to my channel",
-);
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+
+    SlackLogger(webhookUrl: "[Add Your Web Hook Url]");
+
+    return MaterialApp(
+      ...
+    );
+  }
+}
+```
+
+#### Send:
+
+```dart
+final sl = SlackLogger.instance;
+
+...
+
+sl.send("This is a error log to my channel");
+
+...
 ```
 
 Feel Free to request any missing features or report issues [here](https://github.com/slimpotatoboy/slack_logger/issues).

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,9 +8,10 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    SlackLogger(webhookUrl: "[Add Your Web Hook Url]");
+
     return MaterialApp(
       title: 'Slack Logger Example',
       theme: ThemeData(
@@ -31,13 +32,13 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
+  final SlackLogger _sl = SlackLogger.instance;
 
   void _incrementCounter() {
     setState(() {
       _counter++;
     });
-    SlackLogger.send(
-      "[Add Your Web Hook Url]",
+    _sl.send(
       "Count $_counter Added",
     );
   }

--- a/lib/slack_logger.dart
+++ b/lib/slack_logger.dart
@@ -4,10 +4,30 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class SlackLogger {
-  static Future send(String webhookUrl, String message) async {
+  static SlackLogger? _instance;
+  static SlackLogger get instance {
+    _assertInstance();
+    return _instance!;
+  }
+
+  factory SlackLogger({
+    required String webhookUrl,
+  }) {
+    _instance = SlackLogger._internal(webhookUrl);
+
+    return _instance!;
+  }
+
+  SlackLogger._internal(this.webhookUrl);
+
+  final String webhookUrl;
+
+  Future send(String message) async {
+    _assertInstance();
+
     try {
       var postBody = jsonEncode({"text": message});
-      Uri url = Uri.parse(webhookUrl);
+      Uri url = Uri.parse(_instance!.webhookUrl);
       final response = await http.post(
         url,
         headers: {
@@ -25,5 +45,12 @@ class SlackLogger {
     } catch (e) {
       return e.toString();
     }
+  }
+
+  static void _assertInstance() {
+    assert(
+      _instance != null,
+      "[SlackLogger] instance needs to be created first.",
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,39 +18,4 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: slack_logger
 description: A simple dart package to send message to slack channel via slack webhook
-version: 0.0.2
+version: 1.0.0
 repository: https://github.com/slimpotatoboy/slack_logger
 homepage: https://dipenmaharjan.com.np/
 
 environment:
   sdk: '>=2.18.2 <3.0.0'
-  flutter: ">=1.17.0"
+  flutter: '>=1.17.0'
 
 dependencies:
   flutter:

--- a/test/slack_logger_test.dart
+++ b/test/slack_logger_test.dart
@@ -1,7 +1,3 @@
-import 'package:flutter_test/flutter_test.dart';
-
-import 'package:slack_logger/slack_logger.dart';
-
 void main() {
   // test('adds one to input values', () {
   //   final calculator = Calculator();


### PR DESCRIPTION
I was thinking of using this package but when I saw the doc and the code, I found it redundant to pass `webhookUrl` everytime I have to call `.send` method. So, this PR has updated [SlackLogger] class to be a singleton class that can be initialized once and then use the created instance throughout the application.
